### PR TITLE
Respect component dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
 			}
 		},
 		jshint: {
-			all: 'tasks/*.js',
+			all: ['tasks/**/*.js', 'lib/**/*.js'],
 			options: {
 				jshintrc: '.jshintrc'
 			}

--- a/lib/dependencyTools.js
+++ b/lib/dependencyTools.js
@@ -20,9 +20,9 @@ function buildDependencyGraph(module, dependencies, graph) {
 		// Dependency-ception.
 		if(dependency.dependencies) {
 			buildDependencyGraph(
-				dependencyName
-				, dependency.dependencies
-				, graph);
+				dependencyName,
+				dependency.dependencies,
+				graph);
 		}
 	});
 }
@@ -52,10 +52,10 @@ function resolveDependencyGraph(module, resolved, unresolved, dependencies) {
 			}
 
 			resolveDependencyGraph(
-				moduleDependency
-				, resolved
-				, unresolved
-				, dependencies
+				moduleDependency,
+				resolved,
+				unresolved,
+				dependencies
 			);
 		}
 	});
@@ -68,6 +68,6 @@ function resolveDependencyGraph(module, resolved, unresolved, dependencies) {
 
 
 module.exports = {
-	buildDependencyGraph: buildDependencyGraph
-	, resolveDependencyGraph: resolveDependencyGraph
+	buildDependencyGraph: buildDependencyGraph,
+	resolveDependencyGraph: resolveDependencyGraph
 };

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -114,14 +114,14 @@ module.exports = function(grunt) {
 		// Build dependency graph:
 		if(map.dependencies) {
 			dependencyTools.buildDependencyGraph(
-				undefined,    // first recursion without a start value
+				undefined,			// first recursion without a start value
 				map.dependencies,
 				dependencyGraph
 			);
 
 			// Flatten/resolve the dependency tree:
 			dependencyTools.resolveDependencyGraph(
-				undefined, 		// first recursion without a start value
+				undefined,			// first recursion without a start value
 				resolved,
 				unresolved,
 				dependencyGraph


### PR DESCRIPTION
the current implementation of `grunt-bower-concat` does not respect the dependencies of the components on each other.

this pull request contains the creation and resolving of a dependency graph. this allows to decide in which order the components needs to be concated into the destination file.
