### PR TITLE
Supports multiple js files in main. Works with outlayer

### DIFF
--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -135,7 +135,7 @@ module.exports = function(grunt) {
 		// Bower knows main JS file?
 		var mainFiles = ensureArray(component);
 		var mainJSFiles = _.filter(mainFiles, isJsFile);
-		if (mainJSFiles) {
+		if (mainJSFiles.length) {
 			return mainJSFiles;
 		}
 


### PR DESCRIPTION
I added support for a `main` setting with multiple javascript files. See http://github.com/metafizzy/outlayer for the dependency that was failing. 
