### PR TITLE
Check if a mains path does not exist before checking if file

### DIFF
--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -257,7 +257,7 @@ module.exports = function(grunt) {
 		}
 
 		function isJsFile(filepath) {
-			return typeof filepath === 'string' && fs.lstatSync(filepath).isFile() && path.extname(filepath) === '.js';
+			return typeof filepath === 'string' && fs.existsSync(filepath) && fs.lstatSync(filepath).isFile() && path.extname(filepath) === '.js';
 		}
 
 	});


### PR DESCRIPTION
Ran into an issue while concatenating sass-bootstrap, the last main file is really a directory with wildcard and does not resolve as a path.  

Example:
"sass-bootstrap": "~3.0.2" :
"main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css", "./dist/fonts/*"],
