### PR TITLE
Add the option to use minified js files.

### DIFF
--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
 		var dependencies = this.data.dependencies || {};
 		var mains = this.data.mainFiles || {};
 		var bowerOptions = this.data.bowerOptions || {};
-    var useMinFiles = this.data.useMin || true;
+    var useMinFiles = this.data.useMinified || false;
 
 		var done = this.async();
 


### PR DESCRIPTION
useMinFiles added as an optional configuration value, defaults to false.  When true, the main js file(s) defined in the bower.json are checked to see if a '.min.js' file also exists and use it instead.  This allows the use of pre-minified components which is preferred over end user mangling each one. If true, but the min.js file is not found it will preserve and concat the .js file.
