### PR TITLE
Respect bower.config.cwd

### DIFF
--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -146,7 +146,7 @@ module.exports = function(grunt) {
 			// Bower knows main JS file?
 			var mainFiles = ensureArray(component);
 			mainFiles = _.map(mainFiles, function(filepath) {
-				return path.join(bower.config.cwd, filepath)
+				return path.join(bower.config.cwd, filepath);
 			});
 			var mainJSFiles = _.filter(mainFiles, isJsFile);
 			if (mainJSFiles.length) {


### PR DESCRIPTION
Bower has a configuration option `cwd` which allows the _bower_components_ directory to be located at a different location than the project's root directory. For example, my _.bowerrc_ looks like this:

``` json
{
    "cwd": "public",
    "directory": "components"
}
```

We need to take that `cwd` setting (which btw defaults to the project's root directory) into account when searching for the files to be concatenated.
