### PR TITLE
Bower dev dependencies filtering

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,12 @@ bowerOptions: {
   relative: false
 }
 ```
+#### prod
 
+Type: `Boolean`, optional.
+
+This option will filter bower dev dependencies when set to `true`.
+The default value is `true`.
 
 ### Config Example
 

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
 		var dependencies = this.data.dependencies || {};
 		var mains = this.data.mainFiles || {};
 		var callback = this.data.callback;
+		var prod = this.data.prod === false ? false : true ;
 		var bowerOptions = this.data.bowerOptions || {};
 		var bowerDir = bowerOptions.relative !== false ? bower.config.cwd : '';
 
@@ -70,6 +71,14 @@ module.exports = function(grunt) {
 				if (dependencies) {
 					_.map(dependencies, function(value, key) {
 						dependencies[key] = ensureArray(value);
+					});
+				}
+
+				// Filter dev dependencies unless (data.prod === false)
+				var devDependencies = lists.map.pkgMeta.devDependencies;
+				if (devDependencies && prod) {
+					_.each(Object.keys(devDependencies), function(devDependency) {
+						excludes.push(devDependency);
 					});
 				}
 


### PR DESCRIPTION
The goal is to allow bower dev dependencies filtering.

I added an option : `prod`. 
If prod is set to `false`, dev dependencies are concatenated. 
In any other case, they won't be.

Hope it can be of some interest for you !