### PR TITLE
mainFile option does not work if mainfile is valid

### DIFF
--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -194,7 +194,7 @@ module.exports = function(grunt) {
 
 			// Main file explicitly defined in bower_concat options
 			if (mains[name]) {
-				var componentDir = meta && meta.canonicalDir || path.join(bowerDir, component);
+				var componentDir = meta && meta.canonicalDir || path.join(bowerDir, bower.config.directory, name);
 				var manualMainFiles = ensureArray(mains[name]);
 				manualMainFiles = _.map(manualMainFiles, joinPathWith(componentDir));
 				grunt.verbose.writeln('Main file was specified in bower_concat options: ' + manualMainFiles);


### PR DESCRIPTION
This is a weird one, but say you have a dependancy on something like bootstrap, and you don't want to concatenate every one of the main js files.  You want to select which ones you want.

So you have a bower_concat task in grunt a bit like this:
```
bower_concat: {
  all: {
    dest: 'public/depends.js',
    cssDest: 'public/depends.css',
    mainFiles: {
	'bootstrap' : "js/modal.js"
    },
  }
},
```

The intention here is to only include `js/modal.js` from the bootstrap module.

The error I get is as follows:
```
Fatal error: Arguments to path.join must be strings
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at findMainFiles (/opt/example/node_modules/grunt-bower-concat/tasks/bower-concat.js:197:58)
```

So if there is a correct main file, and you try to override which ones you actually want with the above option, you get the error accordingly.

This pull request resolves the error, but is probably not the correct fix.