### PR TITLE
Add pretty output of files which will be concatenated in verbose mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "underscore.string": "~2.3.3"
   },
   "devDependencies": {
+    "filesize": "^3.0.1",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -122,8 +122,8 @@ module.exports = function(grunt) {
 				});
 
 				if (grunt.option('verbose')) {
-					logGroupStats('javascript', allJsFiles);
-					logGroupStats('css', allCssFiles);
+					logGroupStats('Scripts', jsDest, allJsFiles);
+					logGroupStats('Styles', cssDest, allCssFiles);
 					grunt.verbose.writeln();
 				}
 
@@ -449,15 +449,27 @@ module.exports = function(grunt) {
 		 * Verbose print list of files for a group.
 		 *
 		 * @param {String} groupName Name of a files group.
+		 * @param {String} groupDest Path to result of concatenation.
 		 * @param {Array} files List of fileStats
-		 *
 		 */
-		function logGroupStats(groupName, files) {
-			grunt.verbose.writeln();
-			grunt.verbose.writeln('All %s files:', groupName);
+		function logGroupStats(groupName, groupDest, files) {
+			if (!groupDest) {
+				return false;
+			}
+
+			if (!grunt.option('no-color')) {
+				groupDest = groupDest.cyan;
+			}
+
+			grunt.verbose.subhead('%s: -> %s', groupName, groupDest);
 
 			files.forEach(function(file) {
-				grunt.verbose.writeln('  [%s] %s - %s', file.component, file.src, file.size);
+				if (!grunt.option('no-color')) {
+					file.component = file.component.yellow;
+					file.size = file.size.green;
+				}
+
+				grunt.verbose.writeln('  ./%s [%s] - %s', file.src, file.component, file.size);
 			});
 		}
 	});


### PR DESCRIPTION
Easy way to inspect the result of concatenation.

So, result will be like this:

```

$ grunt bower_concat --debug

[D]   Scripts
[D]     [Context.js] bower_components/Context.js/context.js - 7.11 kB
[D]     [backbone-modal] bower_components/backbone-modal/backbone.modal.js - 15.41 kB
[D]     [backbone.babysitter] bower_components/backbone.babysitter/lib/backbone.babysitter.js - 5.23 kB
[D]     [backbone.marionette] bower_components/backbone.marionette/lib/core/backbone.marionette.js - 100.05 kB
[D]     [backbone.wreqr] bower_components/backbone.wreqr/lib/backbone.wreqr.js - 10.82 kB
[D]     [backbone] bower_components/backbone/backbone.js - 59.57 kB
[D]     [fastclick] bower_components/fastclick/lib/fastclick.js - 23.57 kB
[D]     [foundation-datepicker] bower_components/foundation-datepicker/js/foundation-datepicker.js - 38.58 kB
[D]     [foundation] bower_components/foundation/js/foundation.js - 191.8 kB
[D]     [jquery-placeholder] bower_components/jquery-placeholder/jquery.placeholder.js - 5.33 kB
[D]     [jquery.cookie] bower_components/jquery.cookie/jquery.cookie.js - 3.05 kB
[D]     [jquery] bower_components/jquery/dist/jquery.js - 277.52 kB
[D]     [modernizer] bower_components/modernizer/modernizr.js - 50.15 kB
[D]     [underscore] bower_components/underscore/underscore.js - 44.42 kB
[D]
[D]   Styles
[D]     [Context.js] bower_components/Context.js/context.standalone.css - 6.51 kB
[D]     [fontawesome] bower_components/fontawesome/css/font-awesome.css - 26.03 kB
[D]     [foundation-datepicker] bower_components/foundation-datepicker/stylesheets/foundation-datepicker.css - 3.32 kB
[D]     [foundation] bower_components/foundation/css/foundation.css - 189.58 kB
```