### PR TITLE
Add pretty output of files which will be concatenated in verbose mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "underscore.string": "~2.3.3"
   },
   "devDependencies": {
+    "filesize": "^3.0.1",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -79,8 +79,8 @@ module.exports = function(grunt) {
 
 				// List of main files
 				var jsFiles = {};
-				var allJsFiles = [];
-				var allCssFiles = [];
+				var jsGroupStats = [];
+				var cssGroupStats = [];
 				var cssFiles = {};
 
 				_.each(lists.components, function(component, name) {
@@ -99,8 +99,8 @@ module.exports = function(grunt) {
 						});
 
 						if (grunt.option('verbose')) {
-							allJsFiles = allJsFiles.concat(mainJsFiles.map(_.partial(toFileStats, name)));
-							allCssFiles = allCssFiles.concat(mainCssFiles.map(_.partial(toFileStats, name)));
+							jsGroupStats  = jsGroupStats .concat(mainJsFiles.map(_.partial(toFileStats, name)));
+							cssGroupStats = cssGroupStats.concat(mainCssFiles.map(_.partial(toFileStats, name)));
 						}
 
 						jsFiles[name] = mainJsFiles.map(grunt.file.read);
@@ -122,8 +122,8 @@ module.exports = function(grunt) {
 				});
 
 				if (grunt.option('verbose')) {
-					logGroupStats('Scripts', jsDest, allJsFiles);
-					logGroupStats('Styles', cssDest, allCssFiles);
+					logGroupStats('Scripts', jsDest, jsGroupStats);
+					logGroupStats('Styles', cssDest, cssGroupStats);
 					grunt.verbose.writeln();
 				}
 

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -122,8 +122,8 @@ module.exports = function(grunt) {
 				});
 
 				if (grunt.option('verbose')) {
-					logGroupStats('javascript', allJsFiles);
-					logGroupStats('css', allCssFiles);
+					logGroupStats('Scripts', jsDest, allJsFiles);
+					logGroupStats('Styles', cssDest, allCssFiles);
 					grunt.verbose.writeln();
 				}
 
@@ -449,15 +449,27 @@ module.exports = function(grunt) {
 		 * Verbose print list of files for a group.
 		 *
 		 * @param {String} groupName Name of a files group.
+		 * @param {String} groupDest Path to result of concatenation.
 		 * @param {Array} files List of fileStats
-		 *
 		 */
-		function logGroupStats(groupName, files) {
-			grunt.verbose.writeln();
-			grunt.verbose.writeln('All %s files:', groupName);
+		function logGroupStats(groupName, groupDest, files) {
+			if (!groupDest) {
+				return false;
+			}
+
+			if (!grunt.option('no-color')) {
+				groupDest = groupDest.cyan;
+			}
+
+			grunt.verbose.subhead('%s: -> %s', groupName, groupDest);
 
 			files.forEach(function(file) {
-				grunt.verbose.writeln('  [%s] %s - %s', file.component, file.src, file.size);
+				if (!grunt.option('no-color')) {
+					file.component = file.component.yellow;
+					file.size = file.size.green;
+				}
+
+				grunt.verbose.writeln('  ./%s [%s] - %s', file.src, file.component, file.size);
 			});
 		}
 	});


### PR DESCRIPTION
Easy way to inspect the result of concatenation.

So, result will be like this:

```
$ grunt --verbose
....
Scripts: -> test/tmp/with-css.js
  ./components/backbone/backbone.js [backbone] - 54.49 kB
  ./components/jquery-mousewheel/jquery.mousewheel.js [jquery-mousewheel] - 7.18 kB
  ./components/social-likes/social-likes.min.js [social-likes] - 8.52 kB
  ./components/svg.js/dist/svg.js [svg.js] - 72.7 kB
  ./components/underscore/underscore.js [underscore] - 40.45 kB

Styles: -> test/tmp/with-css.css
  ./components/social-likes/social-likes.css [social-likes] - 18.88 kB
....
```