### PR TITLE
add includeWithDependencies functionality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,12 @@ Concatenated files will be joined on this string. If you're post-processing conc
 
 `options: { separator : ';' }`
 
+#### includeWithDependencies
+
+Type: `Boolean`, default: `false`.
+
+True overrides the normal `include` functionality so that dependencies will be included, not just the specified `include` components.
+
 ### Parameters
 
 
@@ -68,7 +74,7 @@ exclude: [
 
 Type: `String|Array`, optional.
 
-By default bower-concat will include all installed in project components. Using `include` option you can manually specify which components should be included.
+By default bower-concat will include all installed in project components. Using `include` option you can manually specify which components should be included. Specifying this will process more like regular concat in that dependencies will not be included automatically.
 
 ```js
 include: [

--- a/tasks/bower-concat.js
+++ b/tasks/bower-concat.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
 		var bowerOptions = this.data.bowerOptions || {};
 		var bowerDir = bowerOptions.relative !== false ? bower.config.cwd : '';
 		var options = this.options({
-			separator: grunt.util.linefeed
+			separator: grunt.util.linefeed,
+			includeWithDependencies: false
 		});
 
 		var done = this.async();
@@ -95,7 +96,7 @@ module.exports = function(grunt) {
 				var cssFiles = {};
 
 				_.each(lists.components, function(component, name) {
-					if (includes.length && _.indexOf(includes, name) === -1) return;
+					if (!options.includeWithDependencies && includes.length && _.indexOf(includes, name) === -1) return;
 					if (excludes.length && _.indexOf(excludes, name) !== -1) return;
 
 					var mainFiles = findMainFiles(name, component, lists.map.dependencies[name]);


### PR DESCRIPTION
Per the discussion https://github.com/sapegin/grunt-bower-concat/issues/52

I've tested this locally, and works as expected.

There's really only two line changes to the code:

* Add the default option value
* Short circuit the logic that would normally skip dependency inclusion when using the `include` directive.

I also added to the Readme.

There were no tests for `include` so there was nothing to change. 