### PR TITLE
Fix config example in readme as cssDest no longer works

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -165,8 +165,10 @@ Include `devDependencies` along with regular `dependencies`.
 ``` javascript
 bower_concat: {
   all: {
-    dest: 'build/_bower.js',
-    cssDest: 'build/_bower.css',
+    dest: {
+      'js': 'build/_bower.js',
+      'css': 'build/_bower.css'
+    },
     exclude: [
       'jquery',
       'modernizr'


### PR DESCRIPTION
I'm not sure which version 'cssDest' was deprecated in, but that option no longer generates a css file.
This PR simply updates the config example in the Readme.